### PR TITLE
Fix compatibility with Foundry 13 and dnd5e 5.0+

### DIFF
--- a/apps/contestedroll.js
+++ b/apps/contestedroll.js
@@ -422,6 +422,7 @@ export class ContestedRoll {
 
                 if (update.roll) {
                     let tooltip = '';
+                    update.roll = MonksTokenBar.intoRoll(update.roll);
                     if (update.roll instanceof Roll) {
                         msgtoken.roll = update.roll.toJSON();
                         if (msgtoken.roll.terms.length)
@@ -576,7 +577,7 @@ export class ContestedRoll {
                 msgtoken.tempreveal = true;
                 if (!msgtoken.roll && update.roll) {
                     //if the roll was not set, then set it
-                    msgtoken.roll = Roll.fromData(update.roll);
+                    msgtoken.roll = MonksTokenBar.intoRoll(update.roll);
                 }
                 flags["token" + update.id] = msgtoken;
                 log("Finish Rolling", msgtoken);

--- a/apps/savingthrow.js
+++ b/apps/savingthrow.js
@@ -768,6 +768,8 @@ export class SavingThrow {
 
                 if (update.roll) {
                     let tooltip = '';
+                    update.roll = MonksTokenBar.intoRoll(update.roll);
+
                     if (update.roll instanceof Roll) {
                         msgtoken.roll = update.roll.toJSON();
                         if (msgtoken.roll.terms.length)
@@ -939,7 +941,7 @@ export class SavingThrow {
                 msgtoken.tempreveal = true;
                 if (!msgtoken.roll && update.roll) {
                     //if the roll was not set, then set it
-                    msgtoken.roll = Roll.fromData(update.roll);
+                    msgtoken.roll = MonksTokenBar.intoRoll(update.roll);
                 }
                 flags["token" + update.id] = msgtoken;
                 log("Finish Rolling message token", foundry.utils.duplicate(msgtoken));

--- a/css/tokenbar.css
+++ b/css/tokenbar.css
@@ -167,6 +167,10 @@ body #tokenbar-window:first-child{
     pointer-events: none;
 }
 
+#token-action-bar .token-list .token {
+    margin: 0;
+}
+
 #tokenbar .token-list {
     flex: 1 1 auto;
     height: 100%;
@@ -521,6 +525,8 @@ body #tokenbar-window:first-child{
     margin: 0;
     white-space: nowrap;
     overflow-x: hidden;
+    font-family: "Modesto Condensed", "Palatino Linotype", serif;
+    font-size: 1.2rem;
 }
 
 .monks-tokenbar .sheet .items-list .item-name h4 .request-name{

--- a/monks-tokenbar.js
+++ b/monks-tokenbar.js
@@ -113,6 +113,17 @@ export class MonksTokenBar {
         return str;
     }
 
+    /**
+     * @param {(Roll|Roll[]|Object)} roll 
+     */
+    static intoRoll(roll) {
+        if (roll instanceof Roll) {
+            return roll;
+        }
+
+        return Roll.fromData(roll);
+    }
+
     static init() {
         log("initializing");
         // element statics
@@ -481,10 +492,7 @@ export class MonksTokenBar {
                     let message = game.messages.get(data.msgid);
                     const revealDice = MonksTokenBar.revealDice();
                     for (let response of data.response) {
-                        if (response.roll) {
-                            let r = Roll.fromData(response.roll);
-                            response.roll = r;
-                        }
+                        response.roll = MonksTokenBar.intoRoll(response.roll);
                     }
                     if (data.type == 'savingthrow')
                         SavingThrow.updateMessage(data.response, message, revealDice);


### PR DESCRIPTION
This PR ensures that the tokenbar can be used with dnd5e 4.1.0 and above.
Note: compatibility with dnd5e < 4.1.0 is dropped.